### PR TITLE
Support values in quotes with whitespace by defining str and pure_str

### DIFF
--- a/exampledata/example.jams
+++ b/exampledata/example.jams
@@ -1,0 +1,8 @@
+{
+    basic_key basic_value
+    list_key [item1 item2]
+    obj_key {
+        key1 val1 
+        key2 val2
+    }
+}

--- a/exampledata/example.jams
+++ b/exampledata/example.jams
@@ -5,4 +5,5 @@
         key1 val1 
         key2 val2
     }
+    str_key "everything; little programs"
 }

--- a/exampledata/example.json
+++ b/exampledata/example.json
@@ -1,0 +1,8 @@
+{
+    "basic_key": "basic_value",
+    "list_key": ["item1", "item2"],
+    "obj_key": {
+        "key1": "val1",
+        "key2": "val2"
+    }
+}

--- a/exampledata/example.json
+++ b/exampledata/example.json
@@ -4,5 +4,6 @@
     "obj_key": {
         "key1": "val1",
         "key2": "val2"
-    }
+    },
+    "str_key": "everything; little programs"
 }

--- a/jams.js
+++ b/jams.js
@@ -14,17 +14,17 @@ HEXDIG               ::= [a-fA-F0-9]
 */
 
 export const read = gram(`
-jam     ::= obj | arr | str
-obj     ::= WS* '{' WS* (duo (WS* duo)*)? WS* '}' WS*
-arr     ::= WS* '[' WS* (jam (WS* jam)*)? WS* ']' WS*
-duo     ::= str WS* jam
-str     ::= SYM | '"' ANY* '"'
-
-WS      ::= [ \t\n\r]+
-SYM     ::= SAFE+
-SYN     ::= '{' | '}' | '[' | ']'
-ANY     ::= (SAFE | WS | SYN)
-SAFE    ::= #x21 | [#x24-#x5A] | [#x5E-#x7A] | #x7C | #x7E
+jam         ::= obj | arr | str | pure_str
+obj         ::= WS* '{' WS* (duo (WS* duo)*)? WS* '}' WS*
+arr         ::= WS* '[' WS* (jam (WS* jam)*)? WS* ']' WS*
+duo         ::= (pure_str | str) WS* jam
+pure_str    ::= SYM
+str         ::= '"' ANY* '"'
+WS          ::= [ \t\n\r]+
+SYM         ::= SAFE+
+SYN         ::= '{' | '}' | '[' | ']'
+ANY         ::= (SAFE | WS | SYN)
+SAFE        ::= #x21 | [#x24-#x5A] | [#x5E-#x7A] | #x7C | #x7E
 `)
 
 export const jams =s=> _jams(read(s))
@@ -34,8 +34,11 @@ const _jams =ast=> {
         case 'jam': {
             return _jams(ast.children[0])
         }
-        case 'str': {
+        case 'pure_str': {
             return ast.text
+        }
+        case 'str': {
+            return ast.text.slice(1, -1)
         }
         case 'arr': {
             const arr = []

--- a/test.js
+++ b/test.js
@@ -2,6 +2,17 @@ import { test } from 'tapzero'
 
 import { jams, read } from './jams.js'
 
+import {readFileSync} from 'fs'
+
+test('json comparison', t=> {
+    const json_o = JSON.parse(readFileSync("./exampledata/example.json"))
+    const jams_o = jams(String(readFileSync('./exampledata/example.jams')))
+    for (const key in json_o) {
+        t.ok(jams_o[key])
+        t.ok(obj_equals(json_o[key], jams_o[key]))
+    }
+})
+
 test('jams', t=>{
     let o = jams('{}')
     t.ok(o)
@@ -98,3 +109,28 @@ test('casetest sample', t=>{
     t.equal(obj.want[0], "")
     t.equal(obj.want[1], "3")
 })
+
+// helper function so that json comparison is cleaner
+function obj_equals(ref_obj, contender_obj) {
+    if (typeof(ref_obj) == 'string') {
+        return ref_obj == contender_obj
+    }
+    if (Array.isArray(ref_obj)) {
+        if (ref_obj.length != contender_obj.length) {
+            return false;
+        }
+        for(let i = 0; i < ref_obj.length; ++i) {
+            if (!obj_equals(ref_obj[i], contender_obj[i])) {
+                return false;
+            }
+        }
+        return true;
+    } 
+    for(const key in ref_obj) {
+        if (!obj_equals(ref_obj[key], contender_obj[key])) {
+            return false;
+        }
+    }
+    return true;
+}
+

--- a/test.js
+++ b/test.js
@@ -51,6 +51,9 @@ test('strings', t=>{
     o = jams('""')
     t.equal("", o)
 
+    o = jams(`{key "multi word value"}`)
+    t.equal(o.key, 'multi word value')
+
     o = jams(`{key "val"}`)
     t.equal(o.key, "val")
 


### PR DESCRIPTION
This PR attempts to solve the problem of support both `barewords` and `"words with spaces in quotes"`. It does so by defining a `pure_str` as any SAFE+ chars, and a `str` as ANY* surrounded by quotes. Then, when parsing `str`, it strips ONLY the first and last quote.

WIP WIP WIP

This builds on #11 and that should be merged first