### PR TITLE
Validate str or q_str for object keys and quoted strings

### DIFF
--- a/jams.js
+++ b/jams.js
@@ -37,7 +37,9 @@ const _jams =ast=> {
         }
         case 'str': {
             if (ast.children.length == 1) {
-                // TODO sanity check it's a string
+                if(!valid_jams_str(ast.children[0])) {
+                    throw new Error(`Bad string: ${ast.text}`)
+                }
                 return _jams(ast.children[0])
             }
             return ast.text
@@ -55,8 +57,11 @@ const _jams =ast=> {
         case 'obj': {
             const out = {}
             for (let duo of ast.children) {
-                const key = _jams(duo.children[0])
-                // TODO assert key is str
+                let key = duo.children[0]
+                if(!valid_jams_str(key)){
+                    throw new Error(`parse error: keys can only be strings. ${key} is not a string`)
+                }
+                key = _jams(key)
                 const val = _jams(duo.children[1])
                 if (out[key] !== undefined) {
                     throw new Error(`parse error: duplicate keys are prohibited at parse time`)
@@ -67,4 +72,8 @@ const _jams =ast=> {
         }
     }
     throw new Error(`panic: unrecognized AST node ${ast.type}`)
+}
+
+const valid_jams_str = (jam) => {
+    return jam.type == 'str' || jam.type == 'q_str'
 }

--- a/jams.js
+++ b/jams.js
@@ -37,7 +37,7 @@ const _jams =ast=> {
         }
         case 'str': {
             if (ast.children.length == 1) {
-                if(!valid_jams_str(ast.children[0])) {
+                if(!(ast.children[0].type == 'str' ||ast.children[0].type == 'q_str' )) {
                     throw new Error(`Bad string: ${ast.text}`)
                 }
                 return _jams(ast.children[0])
@@ -58,7 +58,7 @@ const _jams =ast=> {
             const out = {}
             for (let duo of ast.children) {
                 let key = duo.children[0]
-                if(!valid_jams_str(key)){
+                if(!(key.type == 'str' || key.type == 'q_str')){
                     throw new Error(`parse error: keys can only be strings. ${key} is not a string`)
                 }
                 key = _jams(key)
@@ -72,8 +72,4 @@ const _jams =ast=> {
         }
     }
     throw new Error(`panic: unrecognized AST node ${ast.type}`)
-}
-
-const valid_jams_str = (jam) => {
-    return jam.type == 'str' || jam.type == 'q_str'
 }

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,10 @@ test('strings', t=>{
     o = jams(`{"key" "multi word value"}`)
     t.equal(o.key, "multi word value")
 
+    t.throws(_ => {
+        jams`{{bad key} val}`
+    })
+
     o = jams(`""`)
     t.equal("", o) //err, quotes are being escaped for some reaosn
 


### PR DESCRIPTION
Make sure that if a `str` has a child that it's a `q_str`.
Make sure that an objects key is a valid jams `str` or `q_str`
Add a test for bad keys.