### PR TITLE
Fix file tests

### DIFF
--- a/jams.js
+++ b/jams.js
@@ -37,9 +37,7 @@ const _jams =ast=> {
         }
         case 'str': {
             if (ast.children.length == 1) {
-                if(!valid_jams_str(ast.children[0])) {
-                    throw new Error(`Bad string: ${ast.text}`)
-                }
+                // TODO sanity check it's a string
                 return _jams(ast.children[0])
             }
             return ast.text
@@ -57,11 +55,8 @@ const _jams =ast=> {
         case 'obj': {
             const out = {}
             for (let duo of ast.children) {
-                let key = duo.children[0]
-                if(!valid_jams_str(key)){
-                    throw new Error(`parse error: keys can only be strings. ${key} is not a string`)
-                }
-                key = _jams(key)
+                const key = _jams(duo.children[0])
+                // TODO assert key is str
                 const val = _jams(duo.children[1])
                 if (out[key] !== undefined) {
                     throw new Error(`parse error: duplicate keys are prohibited at parse time`)
@@ -72,8 +67,4 @@ const _jams =ast=> {
         }
     }
     throw new Error(`panic: unrecognized AST node ${ast.type}`)
-}
-
-const valid_jams_str = (jam) => {
-    return jam.type == 'str' || jam.type == 'q_str'
 }

--- a/jams.js
+++ b/jams.js
@@ -37,7 +37,9 @@ const _jams =ast=> {
         }
         case 'str': {
             if (ast.children.length == 1) {
-                // TODO sanity check it's a string
+                if(!valid_jams_str(ast.children[0])) {
+                    throw new Error(`Bad string: ${ast.text}`)
+                }
                 return _jams(ast.children[0])
             }
             return ast.text
@@ -55,8 +57,11 @@ const _jams =ast=> {
         case 'obj': {
             const out = {}
             for (let duo of ast.children) {
-                const key = _jams(duo.children[0])
-                // TODO assert key is str
+                let key = duo.children[0]
+                if(!valid_jams_str(key)){
+                    throw new Error(`parse error: keys can only be strings. ${key} is not a string`)
+                }
+                key = _jams(key)
                 const val = _jams(duo.children[1])
                 if (out[key] !== undefined) {
                     throw new Error(`parse error: duplicate keys are prohibited at parse time`)
@@ -67,4 +72,8 @@ const _jams =ast=> {
         }
     }
     throw new Error(`panic: unrecognized AST node ${ast.type}`)
+}
+
+const valid_jams_str = (jam) => {
+    return jam.type == 'str' || jam.type == 'q_str'
 }

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,10 @@ test('strings', t=>{
     o = jams(`{"key" "multi word value"}`)
     t.equal(o.key, "multi word value")
 
+    t.throws(_ => {
+        jams`{{bad key} val}`
+    })
+
     o = jams(`""`)
     t.equal("", o) //err, quotes are being escaped for some reaosn
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,14 +5,17 @@ import { jams, read } from '../jams.js'
 import { readFileSync, readdirSync } from 'fs'
 
 test('passing files and their JSON equivalents', t=> {
-    readdirSync('./test/pass', filename=>{
-        const jams_o = jams(readFileSync('./pass/${filename}'))
-        const jsonfile = readFileSync('./pass/${filename}.json')
-        if (jsonfile) {
-            const json_o = JSON.parse(jsonfile)
-            for (const key in json_o) {
-                t.ok(jams_o[key])
-                t.ok(obj_equals(json_o[key], jams_o[key]))
+    readdirSync('./test/pass').forEach(filename => {
+        const extension = filename.split('.').slice(-1)
+        if (extension == "jams"){ // only read JAMS, look for json if jams exists
+            const jams_o = jams(readFileSync(`./test/pass/${filename}`))
+            const jsonfile = readFileSync(`./test/pass/${filename}`.replace('jams', 'json'))
+            if (jsonfile) {
+                const json_o = JSON.parse(jsonfile)
+                for (const key in json_o) {
+                    t.ok(jams_o[key])
+                    t.ok(obj_equals(json_o[key], jams_o[key]))
+                }
             }
         }
     })
@@ -58,10 +61,6 @@ test('strings', t=>{
 
     o = jams(`{"key" "multi word value"}`)
     t.equal(o.key, "multi word value")
-
-    t.throws(_ => {
-        jams`{{bad key} val}`
-    })
 
     o = jams(`""`)
     t.equal("", o) //err, quotes are being escaped for some reaosn


### PR DESCRIPTION
The current implementation for file tests fails silently. This is re-implemented to fail loudly and also print the output of tests to the console like the other tests.