### PR TITLE
mandatory space between key and value

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ Q: What does JAMS stand for?
 
 A: Actually-Minimalist JSON Alternative
 
+Q: Where can I find information / documentation for the parser generator which this package depends on?
+
+A: https://github.com/lys-lang/node-ebnf/blob/master/src/Parser.ts

--- a/jams.js
+++ b/jams.js
@@ -17,7 +17,7 @@ export const read = gram(`
 jam          ::= obj | arr | str
 obj          ::= WS* '{' WS* (duo (WS* duo)*)? WS* '}' WS*
 arr          ::= WS* '[' WS* (jam (WS* jam)*)? WS* ']' WS*
-duo          ::= str WS* jam
+duo          ::= str WS+ jam
 str          ::= bare_str  | '"' quoted_str '"'
 bare_str     ::= SAFE+
 quoted_str   ::= ANY*
@@ -28,7 +28,11 @@ SAFE         ::= #x21 | [#x24-#x5A] | [#x5E-#x7A] | #x7C | #x7E
 `)
 // Cast as string as it might be a buffer as from
 // readFilySync
-export const jams =s=> _jams(read(String(s)))
+export const jams =s=> {
+    const ast = read(String(s))
+    if (ast === null) throw new Error('Syntax error')
+    return _jams(ast)
+}
 
 const _jams =ast=> {
     switch (ast.type) {
@@ -61,5 +65,4 @@ const _jams =ast=> {
             return out
         }
     }
-    throw new Error(`panic: unrecognized AST node ${ast.type}`)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -33,12 +33,12 @@ test('jams', t=>{
     t.equal(1, Object.keys(o).length)
     t.equal(o['key'], 'val')
 
-    o = jams('{outer{inner val}}')
+    o = jams('{outer {inner val}}')
     t.ok(o)
     t.equal(1, Object.keys(o).length)
     t.equal(o['outer']['inner'], 'val')
 
-    o = jams('{outer{inner val}smushed{inner val2}}')
+    o = jams('{outer {inner val} smushed {inner val2}}')
     t.ok(o)
     t.equal(o['outer']['inner'], 'val')
     t.equal(o['smushed']['inner'], 'val2')
@@ -54,9 +54,9 @@ test('jams', t=>{
     t.equal(o[1], 'one')
 
     t.throws(_ => {
-        jams('{key{inner val}key{inner val}}')
+        jams('{key val1 key val2}')
     })
-    o = jams('{key{inner val}key2{inner val}}')
+    o = jams('{key1 {inner val} key2 {inner val}}')
     t.ok(o)
 })
 
@@ -72,23 +72,20 @@ test('strings', t=>{
         jams`{{bad key} val}`
     })
 
-    o = jams(`""`)
-    t.equal("", o) //err, quotes are being escaped for some reaosn
+    t.throws(_ => jams(""))
 
     o = jams(`{key "val"}`)
     t.equal(o.key, "val")
 
-    o = jams(`{\"key \"val}`)
-    t.equal(o[`"key`], `"val`)
+    o = jams(`{\"key \" val}`)
+    t.equal(o[`key `], `val`)
 
-    o = jams(`{\\key val}`)
+    o = jams(`{\key val}`)
     t.equal(o[`\key`], `val`)
 
-    o = jams(`{key" val}`)
-    t.ok(!o) // err
+    t.throws(_ => jams(`{key" val}`))
 
-    o = jams(`{"key " val\"\}\}}`)
-    t.equal(o[`"key "`], `val"}`)
+    t.throws(_ => jams(`{"key " val\"\}\}}`))
 })
 
 test('read', t=>{
@@ -120,7 +117,7 @@ test('casetest sample', t=>{
   note "example casetest jams"
   func adder
   args [1 2]
-  want ["" 3]
+  want [3 4]
 }
     `)
     t.ok(obj)
@@ -130,8 +127,8 @@ test('casetest sample', t=>{
     t.equal(obj.args[0], "1")
     t.equal(obj.args[1], "2")
     t.equal(obj.want.length, 2)
-    t.equal(obj.want[0], "")
-    t.equal(obj.want[1], "3")
+    t.equal(obj.want[0], "3")
+    t.equal(obj.want[1], "4")
 })
 
 // helper function so that json comparison is cleaner


### PR DESCRIPTION
Requiring at least 1 whitespace in-between key and value, the reason being edge cases like `{"key "val}` will be easier to understand.