### PR TITLE
minor fixes to parsing function and grammar names

### DIFF
--- a/jams.js
+++ b/jams.js
@@ -18,9 +18,9 @@ jam          ::= obj | arr | str
 obj          ::= WS* '{' WS* (duo (WS* duo)*)? WS* '}' WS*
 arr          ::= WS* '[' WS* (jam (WS* jam)*)? WS* ']' WS*
 duo          ::= str WS+ jam
-str          ::= bare_str  | '"' quoted_str '"'
-bare_str     ::= SAFE+
-quoted_str   ::= ANY*
+str          ::= bare  | '"' quote '"'
+bare         ::= SAFE+
+quote        ::= ANY*
 WS           ::= [ \t\n\r]+
 SYN          ::= '{' | '}' | '[' | ']'
 ANY          ::= (SAFE | WS | SYN)
@@ -29,7 +29,7 @@ SAFE         ::= #x21 | [#x24-#x5A] | [#x5E-#x7A] | #x7C | #x7E
 
 export const jams =s=> {
     // Cast as string so we can accept a few other types
-    str = String(str)
+    const str = String(s)
     const ast = read(str)
     if (ast === null) throw new Error('Syntax error')
     return _jams(ast)

--- a/test/test.js
+++ b/test/test.js
@@ -33,12 +33,12 @@ test('jams', t=>{
     t.equal(1, Object.keys(o).length)
     t.equal(o['key'], 'val')
 
-    o = jams('{outer{inner val}}')
+    o = jams('{outer {inner val}}')
     t.ok(o)
     t.equal(1, Object.keys(o).length)
     t.equal(o['outer']['inner'], 'val')
 
-    o = jams('{outer{inner val}smushed{inner val2}}')
+    o = jams('{outer {inner val} smushed {inner val2}}')
     t.ok(o)
     t.equal(o['outer']['inner'], 'val')
     t.equal(o['smushed']['inner'], 'val2')
@@ -54,9 +54,9 @@ test('jams', t=>{
     t.equal(o[1], 'one')
 
     t.throws(_ => {
-        jams('{key{inner val}key{inner val}}')
+        jams('{key {inner val} key {inner val}}')
     })
-    o = jams('{key{inner val}key2{inner val}}')
+    o = jams('{key {inner val} key2 {inner val}}')
     t.ok(o)
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -33,12 +33,12 @@ test('jams', t=>{
     t.equal(1, Object.keys(o).length)
     t.equal(o['key'], 'val')
 
-    o = jams('{outer {inner val}}')
+    o = jams('{outer{inner val}}')
     t.ok(o)
     t.equal(1, Object.keys(o).length)
     t.equal(o['outer']['inner'], 'val')
 
-    o = jams('{outer {inner val} smushed {inner val2}}')
+    o = jams('{outer{inner val}smushed{inner val2}}')
     t.ok(o)
     t.equal(o['outer']['inner'], 'val')
     t.equal(o['smushed']['inner'], 'val2')
@@ -54,9 +54,9 @@ test('jams', t=>{
     t.equal(o[1], 'one')
 
     t.throws(_ => {
-        jams('{key {inner val} key {inner val}}')
+        jams('{key{inner val}key{inner val}}')
     })
-    o = jams('{key {inner val} key2 {inner val}}')
+    o = jams('{key{inner val}key2{inner val}}')
     t.ok(o)
 })
 


### PR DESCRIPTION
PR makes 3 changes

- Rename quote and bare strings as discussed in matrix
- minor fix to `jams` function that was using `str` when function argument was `s`
- Adds whitespace to tests because otherwise some failing for incorrect reason (they should have been failing because of lack of whitespace, not because of duplicate keys)