### PR TITLE
Support for escaped quotes

### DIFF
--- a/jams.js
+++ b/jams.js
@@ -18,9 +18,9 @@ jam          ::= obj | arr | str
 obj          ::= WS* '{' WS* (duo (WS* duo)*)? WS* '}' WS*
 arr          ::= WS* '[' WS* (jam (WS* jam)*)? WS* ']' WS*
 duo          ::= str WS+ jam
-str          ::= bare_str  | '"' quoted_str '"'
-bare_str     ::= SAFE+
-quoted_str   ::= ANY*
+str          ::= bare  | '"' quote '"'
+bare         ::= SAFE+
+quote        ::= ANY*
 WS           ::= [ \t\n\r]+
 SYN          ::= '{' | '}' | '[' | ']'
 ANY          ::= (SAFE | WS | SYN)
@@ -29,7 +29,7 @@ SAFE         ::= #x21 | [#x24-#x5A] | [#x5E-#x7A] | #x7C | #x7E
 
 export const jams =s=> {
     // Cast as string so we can accept a few other types
-    str = String(str)
+    const str = String(s)
     const ast = read(str)
     if (ast === null) throw new Error('Syntax error')
     return _jams(ast)

--- a/jams.js
+++ b/jams.js
@@ -37,10 +37,11 @@ const _jams =ast=> {
         }
         case 'str': {
             if (ast.children.length == 1) {
-                if(!(ast.children[0].type == 'str' ||ast.children[0].type == 'q_str' )) {
+                let child = ast.children[0]
+                if (child.type != 'q_str') {
                     throw new Error(`Bad string: ${ast.text}`)
                 }
-                return _jams(ast.children[0])
+                return _jams(child)
             }
             return ast.text
         }

--- a/jams.js
+++ b/jams.js
@@ -53,13 +53,13 @@ const _jams =ast=> {
             return ast.children[0].text
         }
         case 'quote': {
-            let children = ast.children
+            const children = ast.children
             let text = ast.text
             for (let child of children) {
                 if (child.type == "unsafe") {
                     // EBNF module re-escapes strings, so "\" becomes "\\"
                     // iff child is of unsafe type do we re-do the unescape
-                    let unescaped = child.text.replace(/\\/, "")
+                    const unescaped = child.text.replace(/\\/, "")
                     // Not SSA, but otherwise we would have to rebuild child by child
                     text = text.replace(child.text, unescaped)
                 }

--- a/jams.js
+++ b/jams.js
@@ -17,7 +17,7 @@ export const read = gram(`
 jam          ::= obj | arr | str
 obj          ::= WS* '{' WS* (duo (WS* duo)*)? WS* '}' WS*
 arr          ::= WS* '[' WS* (jam (WS* jam)*)? WS* ']' WS*
-duo          ::= str WS* jam
+duo          ::= str WS+ jam
 str          ::= bare_str  | '"' quoted_str '"'
 bare_str     ::= SAFE+
 quoted_str   ::= ANY*
@@ -26,9 +26,14 @@ SYN          ::= '{' | '}' | '[' | ']'
 ANY          ::= (SAFE | WS | SYN)
 SAFE         ::= #x21 | [#x24-#x5A] | [#x5E-#x7A] | #x7C | #x7E
 `)
-// Cast as string as it might be a buffer as from
-// readFilySync
-export const jams =s=> _jams(read(String(s)))
+
+export const jams =s=> {
+    // Cast as string so we can accept a few other types
+    str = String(str)
+    const ast = read(str)
+    if (ast === null) throw new Error('Syntax error')
+    return _jams(ast)
+}
 
 const _jams =ast=> {
     switch (ast.type) {

--- a/test/pass/example.jams
+++ b/test/pass/example.jams
@@ -6,4 +6,6 @@
         key2 val2
     }
     str_key "everything; little programs"
+    escape_key "this string has a \" in it"
+    multi_escape_key "this string \" has a \"multiple escapes"
 }

--- a/test/pass/example.json
+++ b/test/pass/example.json
@@ -5,5 +5,8 @@
         "key1": "val1",
         "key2": "val2"
     },
-    "str_key": "everything; little programs"
+    "str_key": "everything; little programs",
+    "escape_key": "this string has a \" in it",
+    "multi_escape_key": "this string \" has a \"multiple escapes"
+
 }

--- a/test/test.js
+++ b/test/test.js
@@ -33,12 +33,12 @@ test('jams', t=>{
     t.equal(1, Object.keys(o).length)
     t.equal(o['key'], 'val')
 
-    o = jams('{outer{inner val}}')
+    o = jams('{outer {inner val}}')
     t.ok(o)
     t.equal(1, Object.keys(o).length)
     t.equal(o['outer']['inner'], 'val')
 
-    o = jams('{outer{inner val}smushed{inner val2}}')
+    o = jams('{outer {inner val} smushed {inner val2}}')
     t.ok(o)
     t.equal(o['outer']['inner'], 'val')
     t.equal(o['smushed']['inner'], 'val2')
@@ -54,9 +54,9 @@ test('jams', t=>{
     t.equal(o[1], 'one')
 
     t.throws(_ => {
-        jams('{key{inner val}key{inner val}}')
+        jams('{key {inner val} key {inner val}}')
     })
-    o = jams('{key{inner val}key2{inner val}}')
+    o = jams('{key {inner val} key2 {inner val}}')
     t.ok(o)
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -72,8 +72,8 @@ test('strings', t=>{
         jams`{{bad key} val}`
     })
 
-    o = jams(`{key "val"}`)
-    t.equal(o.key, "val")
+    o = jams(String.raw`{"\"key" "\"val"}`) // Need raw so js doesn't escape \
+    t.equal(o[`"key`], `"val`)
 
     o = jams(`{\"key \"val}`)
     t.equal(o[`"key`], `"val`)

--- a/test/test.js
+++ b/test/test.js
@@ -72,13 +72,6 @@ test('strings', t=>{
         jams`{{bad key} val}`
     })
 
-    o = jams(String.raw`{"\"key" "\"val"}`)
-    console.log(o)
-    t.equal(o[`"key`], `"val`)
-
-    o = jams(`""`)
-    t.equal("", o) //err, quotes are being escaped for some reaosn
-
     o = jams(`{key "val"}`)
     t.equal(o.key, "val")
 
@@ -93,6 +86,9 @@ test('strings', t=>{
 
     o = jams(`{"key " val\"\}\}}`)
     t.equal(o[`"key "`], `val"}`)
+
+    o = jams(`""`)
+    t.equal("", o) //err, quotes are being escaped for some reaosn
 })
 
 test('read', t=>{


### PR DESCRIPTION
PR includes changes from #22, that one can be merged first to see true diff.

There is a problem with the ebnf module we use -- it auto escapes strings somewhere in its implementation. For example the string:
```
`{key "val\""}`
```
is re-escaped to
```
`{key "val\\""}`
```
within the ebnf module itself.

So to address this I implemented
- introduce `unsafe` type (only supports escaped quotes for now)
- Only allowing `unsafe` to exist within `quote`
- parsing `quote` child by child, and replacing the re-escaped characters only if the child is of type `unsafe`

We could redefine the grammar to expect the double `\\`, but this would be an inaccurate grammar tailored to our specific parser.

Added new file based tests that are all passing. If we have a list of other characters that should be escaped, I can add them too. 