### PR TITLE
Print pass/fail dir in test names

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ test('passing files and their JSON equivalents', _=> {
         const extension = filename.split('.').slice(-1)[0]
 	// Only read JAMS files, and we require a corresponding JSON verison.
         if (extension === "jams") {
-	    test(filename, t=> {
+	    test(`${subpath}/${filename}`, t=> {
 		const jamspath = `${subpath}/${filename}`
 	        const jams_o = jams(readFileSync(jamspath, {encoding: 'utf8'}))
 	        const jsonfile = readFileSync(jamspath.replace('jams', 'json'))
@@ -28,7 +28,7 @@ test('passing files and their JSON equivalents', _=> {
 test('failing files', t=> {
     const subpath = './test/fail'
     readdirSync(subpath).forEach(filename => {
-		test(filename, t => {
+		test(`${subpath}/${filename}`, t => {
         const extension = filename.split('.').slice(-1)[0]
 	const filepath = `${subpath}/${filename}`
         if (extension === "jams") {


### PR DESCRIPTION
Currently the tests just print the filename without a path. This makes it unclear from test output where the test is located and if the intent is for it to fail or pass, and what failing/passing means for that test.

Prior:
```sh
# passing files and their JSON equivalents
# failing files
# bare1.jams
ok 1 should be equivalent
ok 2 should be truthy
ok 3 should be equivalent
# bare2.jams
...
# angle-bracket.jams
ok 53 show throw
```

Now:
```sh
# passing files and their JSON equivalents
# failing files
# ./test/pass/bare1.jams
ok 1 should be equivalent
ok 2 should be truthy
ok 3 should be equivalent
...
# ./test/fail/angle-bracket.jams
ok 53 show throw
```